### PR TITLE
Fix timer interactions and persist cycle data

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,8 +211,10 @@ function formatSecondsForCSV(ms){const secs=(ms/1000).toFixed(2); return lang===
 let laps=[]; // {ms,note}
 let running=false, tStart=0, tick=null;
 let selectedIndex=-1;
+const STORAGE_KEY='cycle-check-state-v1';
 
 /* ===== UI refs ===== */
+const processInput=$('#process'), dateInput=$('#date');
 const toggleBtn=$('#btnToggle'), stopBtn=$('#btnStop'), timerDisp=$('#timerDisp'), statusEl=$('#status');
 const chart=$('#chart'), ctx=chart.getContext('2d',{willReadFrequently:true});
 
@@ -248,8 +250,11 @@ function startTimer(){
   stopBtn.disabled=false;
   status(L[lang].MEASURE);
 }
-function addLap(ms,note=''){ laps.push({ms,note}); renderList(); drawChart(); updateKPIs(); }
-function lap(){ // spara & fortsätt direkt
+function addLap(ms,note=''){
+  laps.push({ms,note});
+  refreshUI();
+}
+function lap(){
   if(!running) return;
   const elapsed=Math.max(10, performance.now()-tStart);
   addLap(elapsed);
@@ -258,12 +263,13 @@ function lap(){ // spara & fortsätt direkt
   timerDisp.textContent='00:00.00';
 }
 function stopTimer(){
-  if(!running) return;
-  clearInterval(tick); tick=null; running=false;
-  stopBtn.disabled=true;
+  if(running){
+    clearInterval(tick); tick=null; running=false;
+    stopBtn.disabled=true;
+    toggleBtn.textContent=L[lang].TOGGLE_START;
+    status(L[lang].STOPPED);
+  }
   timerDisp.textContent='00:00.00';
-  toggleBtn.textContent=L[lang].TOGGLE_START;
-  status(L[lang].STOPPED);
 }
 function toggle(){ running ? lap() : startTimer(); }
 
@@ -280,7 +286,7 @@ window.addEventListener('keydown', e=>{
     e.preventDefault();
     running ? lap() : startTimer();
   }
-  if(e.key.toLowerCase()==='s'){ // s = stop
+  if(e.key && e.key.toLowerCase()==='s'){
     if(tag!=='TEXTAREA' && tag!=='INPUT'){ e.preventDefault(); stopTimer(); }
   }
   if(e.key==='Delete' || e.key==='Backspace'){
@@ -299,7 +305,8 @@ function deleteSelected(){
   if(selectedIndex<0 || selectedIndex>=laps.length) return;
   laps.splice(selectedIndex,1);
   selectedIndex=-1;
-  renderList(); drawChart(); updateKPIs();
+  refreshUI();
+  status(L[lang].SAVED);
 }
 
 /* ===== Lista/KPI/Diagram ===== */
@@ -312,21 +319,21 @@ function renderList(){
       `<div class="cell cycle"><span class="badge">#${i+1}</span></div>
        <div class="cell time"><b>${formatMs(l.ms)}</b></div>
        <div class="cell problems">
-         <textarea data-ix="${i}" placeholder=""></textarea>
+         <textarea data-ix="${i}" placeholder="${L[lang].PROBLEMS}"></textarea>
        </div>
        <div class="delete-cell"><button class="delete-btn" title="Delete" data-ix="${i}">🗑️</button></div>`;
     list.appendChild(row);
     const ta=row.querySelector('textarea'); ta.value=l.note||'';
     row.addEventListener('click', ()=> selectRow(i));
     ta.addEventListener('focus', ()=> selectRow(i));
-    ta.addEventListener('input', e=>{ const ix=+e.target.dataset.ix; laps[ix].note=e.target.value; });
+    ta.addEventListener('input', e=>{ const ix=+e.target.dataset.ix; laps[ix].note=e.target.value; saveState(); });
   });
   list.querySelectorAll('.delete-btn').forEach(btn=>btn.addEventListener('click',e=>{
     e.stopPropagation();
     const ix=+e.currentTarget.dataset.ix;
     laps.splice(ix,1);
     if(selectedIndex===ix) selectedIndex=-1; else if(selectedIndex>ix) selectedIndex--;
-    renderList(); drawChart(); updateKPIs();
+    refreshUI();
   }));
 }
 function avgMs(a){return a.length? a.reduce((x,y)=>x+y,0)/a.length:0}
@@ -340,31 +347,191 @@ function updateKPIs(){
 
 /* ===== Diagram (blå nyanser på staplarna) ===== */
 function drawChart(){
-  const dpr=window.devicePixelRatio||1, W=chart.clientWidth*dpr, H=chart.clientHeight*dpr;
+  const dpr=window.devicePixelRatio||1;
+  const clientW=Math.max(1,chart.clientWidth), clientH=Math.max(1,chart.clientHeight);
+  const W=clientW*dpr, H=clientH*dpr;
   chart.width=W; chart.height=H; ctx.clearRect(0,0,W,H);
-  const padL=64*dpr, padR=16*dpr, padT=14*dpr, padB=34*dpr, innerW=W-padL-padR, innerH=H-padT-padB;
-  const maxMs=Math.max(10000,...laps.map(l=>l.ms));
-  const maxS=Math.ceil(maxMs/10000)*10;
+  const padL=64*dpr, padR=18*dpr, padT=16*dpr, padB=42*dpr, innerW=W-padL-padR, innerH=H-padT-padB;
+  if(innerW<=0 || innerH<=0) return;
+  const maxMs=laps.length?Math.max(...laps.map(l=>l.ms),10000):10000;
+  const maxS=Math.max(10,Math.ceil(maxMs/1000/10)*10);
   const msToY = ms => padT+innerH-(ms/(maxS*1000))*innerH;
 
-  // ram
   ctx.strokeStyle='#cbd5e1'; ctx.lineWidth=1*dpr; ctx.strokeRect(padL,padT,innerW,innerH);
 
-  // grid / Y-etiketter var 30s
   ctx.fillStyle='#475569'; ctx.font=`${11*dpr}px system-ui,-apple-system,Segoe UI,Inter,Arial`;
+  ctx.textBaseline='middle';
   for(let s=0;s<=maxS;s+=30){
     const y=msToY(s*1000);
     ctx.strokeStyle=s===0?'#cbd5e1':'#e5e7eb';
     ctx.beginPath(); ctx.moveTo(padL,y); ctx.lineTo(W-padR,y); ctx.stroke();
     const m=Math.floor(s/60), sec=s%60;
-    ctx.textAlign='left'; ctx.textBaseline='middle';
     ctx.fillText(`${String(m).padStart(2,'0')}:${String(sec).padStart(2,'0')}`,8*dpr,y);
   }
 
-  // staplar – blå palett (nyanser)
   const n=laps.length;
   if(n){
-    const gap=6*dpr, bw=Math.max(8*dpr,(innerW-gap*(n-1))/n);
+    const gap=6*dpr, bw=Math.max(10*dpr,(innerW-gap*(n-1))/n);
+    const palette=['#bfdbfe','#93c5fd','#60a5fa','#3b82f6','#2563eb'];
     for(let i=0;i<n;i++){
       const l=laps[i];
-      const x=padL+i*(bw+gap), y=msToY(l*
+      const x=padL+i*(bw+gap);
+      const y=msToY(l.ms);
+      const h=msToY(0)-y;
+      ctx.fillStyle=palette[i%palette.length];
+      ctx.fillRect(x,y,bw,h);
+      ctx.fillStyle='#1f2937'; ctx.font=`${10*dpr}px system-ui,-apple-system,Segoe UI,Inter,Arial`;
+      ctx.textAlign='center'; ctx.textBaseline='top';
+      ctx.fillText(`#${i+1}`,x+bw/2,H-padB+6*dpr);
+    }
+
+    const arr=laps.map(l=>l.ms);
+    const avg=avgMs(arr);
+    if(arr.length){
+      const yAvg=msToY(avg);
+      ctx.setLineDash([6*dpr,4*dpr]);
+      ctx.strokeStyle='#f97316'; ctx.lineWidth=1.5*dpr;
+      ctx.beginPath(); ctx.moveTo(padL,yAvg); ctx.lineTo(W-padR,yAvg); ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.fillStyle='#f97316'; ctx.textAlign='right'; ctx.textBaseline='bottom';
+      ctx.fillText('Ø CT',W-4*dpr,yAvg-4*dpr);
+    }
+    const br=brctMs(arr);
+    if(br!==null){
+      const yBr=msToY(br);
+      ctx.setLineDash([4*dpr,3*dpr]);
+      ctx.strokeStyle='#16a34a'; ctx.lineWidth=1.5*dpr;
+      ctx.beginPath(); ctx.moveTo(padL,yBr); ctx.lineTo(W-padR,yBr); ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.fillStyle='#16a34a'; ctx.textAlign='right'; ctx.textBaseline='top';
+      ctx.fillText('BRCT',W-4*dpr,yBr+4*dpr);
+    }
+  }
+}
+
+function refreshUI({save=true}={}){
+  renderList();
+  drawChart();
+  updateKPIs();
+  if(save) saveState();
+}
+
+function saveState(){
+  try{
+    const payload={
+      lang,
+      theme,
+      laps:laps.map(l=>({ms:l.ms,note:l.note||''})),
+      process:processInput.value||'',
+      date:dateInput.value||''
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  }catch(err){
+    console.warn('Failed to save state', err);
+  }
+}
+
+function loadState(){
+  try{
+    const raw=localStorage.getItem(STORAGE_KEY);
+    if(!raw) return;
+    const stored=JSON.parse(raw);
+    if(stored && typeof stored==='object'){
+      if(stored.lang && L[stored.lang]) lang=stored.lang;
+      if(stored.theme) theme=stored.theme;
+      if(Array.isArray(stored.laps)){
+        laps=stored.laps
+          .map(item=>({ms:Number(item.ms)||0,note:item.note||''}))
+          .filter(item=>item.ms>0);
+      }
+      if(typeof stored.process==='string') processInput.value=stored.process;
+      if(typeof stored.date==='string') dateInput.value=stored.date;
+    }
+  }catch(err){
+    console.warn('Failed to load state', err);
+  }
+}
+
+function resetApp(){
+  if(!confirm(L[lang].CONFIRM_RESET)) return;
+  if(running) stopTimer(); else { timerDisp.textContent='00:00.00'; }
+  laps=[];
+  selectedIndex=-1;
+  processInput.value='';
+  dateInput.value='';
+  refreshUI();
+  status(L[lang].RESETTED);
+}
+
+function exportCSV(){
+  const rows=[];
+  rows.push(['Process', processInput.value||'']);
+  rows.push(['Date', dateInput.value||'']);
+  rows.push([]);
+  rows.push([L[lang].CYCLE,'ms',L[lang].TIMES,L[lang].PROBLEMS]);
+  laps.forEach((lap,i)=>{
+    rows.push([
+      `#${i+1}`,
+      lap.ms,
+      formatSecondsForCSV(lap.ms),
+      (lap.note||'').replace(/\n/g,' ')
+    ]);
+  });
+  const csv=rows.map(r=>r.map(v=>`"${String(v??'').replace(/"/g,'""')}"`).join(',')).join('\n');
+  const blob=new Blob([csv],{type:'text/csv;charset=utf-8;'});
+  const url=URL.createObjectURL(blob);
+  const a=document.createElement('a');
+  a.href=url;
+  const stamp=new Date().toISOString().slice(0,10);
+  a.download=`20-cycle-check-${stamp}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+  status(L[lang].SAVED);
+}
+
+function setLanguage(newLang){
+  if(!L[newLang]) return;
+  lang=newLang;
+  setLangTexts();
+  refreshUI();
+}
+
+function cycleTheme(){
+  theme=theme==='auto'?'light':theme==='light'?'dark':'auto';
+  applyTheme(theme);
+  saveState();
+}
+
+function initEventHandlers(){
+  document.querySelectorAll('#langbar .flagbtn').forEach(btn=>{
+    btn.addEventListener('click',()=>{ setLanguage(btn.dataset.lang); });
+  });
+  $('#btnTheme').addEventListener('click',cycleTheme);
+  $('#btnReset').addEventListener('click',resetApp);
+  $('#btnExport').addEventListener('click',exportCSV);
+  processInput.addEventListener('input',()=>saveState());
+  dateInput.addEventListener('input',()=>saveState());
+  window.addEventListener('resize',()=>drawChart());
+  const media=window.matchMedia('(prefers-color-scheme: dark)');
+  const mediaHandler=()=>{ if(theme==='auto') applyTheme('auto'); };
+  if(media.addEventListener) media.addEventListener('change',mediaHandler);
+  else if(media.addListener) media.addListener(mediaHandler);
+}
+
+function init(){
+  loadState();
+  applyTheme(theme);
+  setLangTexts();
+  refreshUI({save:false});
+  stopBtn.disabled=true;
+  timerDisp.textContent='00:00.00';
+  status(L[lang].READY);
+  initEventHandlers();
+}
+
+document.addEventListener('DOMContentLoaded', init);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restore the timer start/lap/stop logic and keyboard shortcuts so the Start button works again
- rebuild list, KPI, and chart rendering with blue bars plus average/BRCT overlays
- add localStorage persistence, language/theme toggles, reset/export handlers, and CSV export formatting

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dc3750ce88832da1acc68d470e277e